### PR TITLE
use gem_package over package

### DIFF
--- a/user_docs/installation_instructions.md
+++ b/user_docs/installation_instructions.md
@@ -36,9 +36,9 @@ sensu_gem 'sensu-plugins-disk-checks' do
 end
 ```
 
-Using the Chef **package** resource
+Using the Chef **gem_package** resource
 ```
-package 'sensu-plugins-disk-checks' do
+gem_package 'sensu-plugins-disk-checks' do
   options('--prerelease') # only needed if it is in an alpha state
   version '0.0.1.alpha.1'
 end


### PR DESCRIPTION
gem_package is the equivalent of:

```
package 'sensu-plugins-disk-checks' do
  provider Chef::Provider::Package::Rubygems
  options('--prerelease') # only needed if it is in an alpha state
  version '0.0.1.alpha.1'
end
```
